### PR TITLE
fix : 리뷰 등록 시 반대되는 키워드 중에 하나만 선택할 수 있게 하고, 리뷰 상세에서 선택된 만큼 키워드 보여주게 수정

### DIFF
--- a/static/reg_reviews.js
+++ b/static/reg_reviews.js
@@ -137,10 +137,41 @@ for (let i = 0; i < 5; i++) {
 
 
 // 키워드 선택 시 스타일 변경
+const exclusives = [
+    ["seller-good", "seller-bad"],
+    ["info-good", "info-bad"],
+    ["recom", "no-recom"]
+];
 
 const keywordSelect = document.querySelectorAll(".keyword-set");
-keywordSelect.forEach(element => {
-    element.addEventListener("click", () => {
-        element.classList.toggle("active");
-    })
+keywordSelect.forEach(label => {
+    label.addEventListener("click", (event) => {
+        event.preventDefault(); // 기본 동작 방지 (체크박스 클릭 반영 방지)
+        const checkboxId = label.getAttribute("for");
+        const checkbox = document.querySelector(`#${checkboxId}`);
+
+        if (checkbox.checked) {
+            // 이미 선택된 상태라면 해제
+            checkbox.checked = false;
+            label.classList.remove("active");
+        } else {
+            // 새로운 선택 처리
+            exclusives.forEach(group => {
+                if (group.includes(checkboxId)) {
+                    group.forEach(itemId => {
+                        const otherCheckbox = document.querySelector(`#${itemId}`);
+                        const otherLabel = document.querySelector(`label[for='${itemId}']`);
+
+                        // 그룹 내 다른 체크박스 및 라벨 초기화
+                        otherCheckbox.checked = false;
+                        otherLabel.classList.remove("active");
+                    });
+                }
+            });
+
+            // 현재 선택 활성화
+            checkbox.checked = true;
+            label.classList.add("active");
+        }
+    });
 });

--- a/templates/review_detail.html
+++ b/templates/review_detail.html
@@ -1,8 +1,8 @@
 {% extends "index.html" %}
 
 {% block head %}
-    <title>상품 리뷰 상세 페이지</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/review_detail.css') }}">
+<title>상품 리뷰 상세 페이지</title>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/review_detail.css') }}">
 {% endblock %}
 
 {% block section %}
@@ -32,7 +32,7 @@
                     {% elif data.rate_item == "4" %}
                     ★★★★☆
                     {% elif data.rate_item == "5" %}
-                     ★★★★★
+                    ★★★★★
                     {% endif %} </p>
                 <p>배송 상태 만족도 : {% if data.rate_deliver == "0" %}
                     ☆☆☆☆☆
@@ -47,10 +47,10 @@
                     {% elif data.rate_deliver == "5" %}
                     ★★★★★
                     {% endif %} </p>
-                <p>키워드 : 
-                    <span class="keyword">{{data.keywords[0]}}</span>
-                    <span class="keyword">{{data.keywords[1]}}</span>
-                    <span class="keyword">{{data.keywords[2]}}</span>
+                <p>키워드 :
+                    {% for keyword in data.keywords %}
+                    <span class="keyword">{{ keyword }}</span>
+                    {% endfor %}
                     <!--<span class="keyword2">+ 더보기</span>-->
                 </p>
                 <p>작성자 : {{data.reviewer_id}} </p>
@@ -58,15 +58,16 @@
 
             <!-- 오른쪽 영역: 이미지 -->
             <div class="review-images">
-                <div class="image-box"><img src="../../static/images/{{data.img_path}}" width="350px"height="250px"></div> <!-- 이미지 공간 -->
+                <div class="image-box"><img src="../../static/images/{{data.img_path}}" width="350px" height="250px">
+                </div> <!-- 이미지 공간 -->
             </div>
         </form>
     </div>
-        
+
     <!-- 하단 리뷰 내용 박스 -->
     <div class="review-content">
         <p>{{data.review}}</p>
-        
+
     </div>
 </div>
 


### PR DESCRIPTION
## 💻 담당한 파트
> ex) FE, BE

FE

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요(이미지 첨부 가능)

리뷰 등록 페이지에서 키워드 선택할 때, "판매자 불친절"이 선택된 상황에서 "판매자 친절함"을 누르면 판매자 불친절이 자동으로 취소되고 판매자 친절함이 선택되게 하는 것처럼 각 키워드마다 반대되는 키워드 중 하나만 선택될 수 있게 했습니다. 키워드를 누르면 선택/미선택되게끔하는 것은 유지했습니다. 그리고, 이를 바탕으로 리뷰 상세에서 기존에는 무조건 3개의 키워드만 보여주게 했는데, 키워드가 선택된 만큼은 보여지게 수정했습니다. 리뷰 등록 페이지에서 키워드를 최대 3개밖에 선택할 수밖에 없어서 더보기는 없애도 될 것 같습니다!!



## 📢 Notes(선택)
> 리뷰어가 봐주었으면 하는 부분이 있다면 작성해주세요!>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

기존에 리뷰 데이터를 지울 필요가 있을 것 같습니다!! 제일 최근의 리뷰의 경우 6개의 키워드가 선택되어 있는데 지금 상황에서는 발생할 수 없는 리뷰라서요!!!