### PR TITLE
fix: 상단 메뉴 active랑   카테고리랑 class 이름이 겹쳐서 css 잘 못 적용되는 현상 해결

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -62,7 +62,7 @@
 	color: #939393;
 	text-decoration: none;
 }
-.active {
+.menu-title-active {
 	font-size: 1.2rem;
 	color: #ffffff;
 	font-weight: bold;

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,11 +23,11 @@
     </form>
 </div>
 <ul class="navbar__menu">
-    <li><a class="  {% if 'list' in request.path %}active{% else %} menu-title {% endif %}" href="/list">상품 목록</a></li>
-    <li><a class="{% if 'review' in request.path %}active{% else %} menu-title{% endif %}" href="/review">상품 리뷰</a></li>
+    <li><a class="  {% if 'list' in request.path %}menu-title-active{% else %} menu-title {% endif %}" href="/list">상품 목록</a></li>
+    <li><a class="{% if 'review' in request.path %}menu-title-active{% else %} menu-title{% endif %}" href="/review">상품 리뷰</a></li>
     
     {% if session['id'] %}
-    <li><a class="{% if 'reg_items' in request.path %}active {% else %} menu-title {% endif %}" href="/reg_items">상품 등록</a></li>
+    <li><a class="{% if 'reg_items' in request.path %}menu-title-active {% else %} menu-title {% endif %}" href="/reg_items">상품 등록</a></li>
     <li class="mypage-container">
         <div class="white-container">
             <div class="id-container">{{session['id']}}</div>


### PR DESCRIPTION
## 💻 담당한 파트
> ex) FE, BE

FE

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요(이미지 첨부 가능)

상단 메뉴 active랑   카테고리랑 class 이름이 겹쳐서 css 잘 못 적용되는 현상 해결

## 📢 Notes(선택)
> 리뷰어가 봐주었으면 하는 부분이 있다면 작성해주세요!>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?